### PR TITLE
OCI Monitoring Post Metric example

### DIFF
--- a/examples/javascript/monitoring-post-metric.js
+++ b/examples/javascript/monitoring-post-metric.js
@@ -8,6 +8,8 @@
  *  <li>The first argument is the OCID of the compartment.</li>
  * </ul>
  * Refer https://docs.cloud.oracle.com/en-us/iaas/api/#/en/monitoring/20180401/MetricData/PostMetricData for more details.
+ * This example uses phoenix metric endpoint https://telemetry-ingestion.us-phoenix-1.oraclecloud.com 
+ * we can change this to a different region (refer https://docs.cloud.oracle.com/en-us/iaas/api/#/en/monitoring/20180401/).
  */
 
 const mt = require("oci-monitoring");
@@ -48,22 +50,22 @@ monitoringClient.endpoint = "https://telemetry-ingestion.us-phoenix-1.oracleclou
     */
 
     const MetricDataDetails = [{
-        "namespace": "mushopnamespace",
-        "resourceGroup": "mushop-rg",
+        "namespace": "<your_namespace_here>",
+        "resourceGroup": "<your_resourcegroup_here>",
         "compartmentId": compartmentId,
-        "name": "mushop-401-http-error",
+        "name": "<your_name_of_the_metric_here>",
         "dimensions": {
-            "appName": "Mushop",
-            "podName": "mushop-storefront"
+            "appName": "<your_dimensions>",
+            "podName": "<your_dimensions>"
         },
         "metadata": {
             "unit": "count",
-            "displayName": "MuShop Authorization errors"
+            "displayName": "<your_display_name>"
         },
         "datapoints": [{
             "timestamp": dateutc,
-            "value": 43,
-            "count": 43
+            "value": "<your_datapoint_value>",
+            "count": "<your_datapoint_count>"
         }
       ]
     }]

--- a/examples/javascript/monitoring-post-metric.js
+++ b/examples/javascript/monitoring-post-metric.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+
+ /* @param args Arguments to provide to the example. The following arguments are expected:
+ * <ul>
+ *  <li>The first argument is the OCID of the compartment.</li>
+ * </ul>
+ * Refer https://docs.cloud.oracle.com/en-us/iaas/api/#/en/monitoring/20180401/MetricData/PostMetricData for more details.
+ */
+
+const mt = require("oci-monitoring");
+const common = require("oci-common");
+
+const configurationFilePath = "~/.oci/config";
+const configProfile = "DEFAULT";
+
+const provider = new common.ConfigFileAuthenticationDetailsProvider(
+  configurationFilePath,
+  configProfile
+);
+
+const args = process.argv.slice(1);
+console.log(args);
+if (args.length !== 2) {
+  console.error(
+    "Unexpected number of arguments received. Usage : monitoring-alarm.ts <MetricCompartment>"
+  );
+  process.exit(-1);
+}
+
+const compartmentId = args[1];
+
+const monitoringClient = new mt.MonitoringClient({
+  authenticationDetailsProvider: provider
+});
+monitoringClient.region = common.Region.US_PHOENIX_1;
+monitoringClient.endpoint = "https://telemetry-ingestion.us-phoenix-1.oraclecloud.com";
+
+(async () => {
+  try {
+
+    var datenow = new Date();
+    var dateutc = new Date(datenow.toUTCString());
+    /* The timestamp datapoint format used is defined by RFC3339. 
+    https://docs.cloud.oracle.com/en-us/iaas/api/#/en/monitoring/20180401/datatypes/Datapoint
+    */
+
+    const MetricDataDetails = [{
+        "namespace": "mushopnamespace",
+        "resourceGroup": "mushop-rg",
+        "compartmentId": compartmentId,
+        "name": "mushop-401-http-error",
+        "dimensions": {
+            "appName": "Mushop",
+            "podName": "mushop-storefront"
+        },
+        "metadata": {
+            "unit": "count",
+            "displayName": "MuShop Authorization errors"
+        },
+        "datapoints": [{
+            "timestamp": dateutc,
+            "value": 43,
+            "count": 43
+        }
+      ]
+    }]
+
+    const PostMetricDataDetails = {
+      "metricData" : MetricDataDetails
+    }
+
+    const PostMetricDataRequest = {
+      "postMetricDataDetails": PostMetricDataDetails
+    };
+
+    const post_response =  await monitoringClient.postMetricData(PostMetricDataRequest);
+    //console.log("Retrieved :" + response.postMetricDataResponseDetails.failedMetricsCount);
+
+    console.log("Successfully posted custom metric with name: %s to namespace: %s in region: %s",MetricDataDetails[0].name,MetricDataDetails[0].namespace,common.Region.US_PHOENIX_1._regionId )
+
+  } catch (error) {
+    console.log(" Not able to run post metric monitoring example. Error: " + error);
+  }
+})();

--- a/examples/typescript/monitoring-post-metric.ts
+++ b/examples/typescript/monitoring-post-metric.ts
@@ -8,6 +8,8 @@
  *  <li>The first argument is the OCID of the compartment.</li>
  * </ul>
  * Refer https://docs.cloud.oracle.com/en-us/iaas/api/#/en/monitoring/20180401/MetricData/PostMetricData for more details.
+ * This example uses phoenix metric endpoint https://telemetry-ingestion.us-phoenix-1.oraclecloud.com 
+ * we can change this to a different region (refer https://docs.cloud.oracle.com/en-us/iaas/api/#/en/monitoring/20180401/).
  */
 
 import mt = require("oci-monitoring");
@@ -49,22 +51,22 @@ monitoringClient.endpoint = "https://telemetry-ingestion.us-phoenix-1.oracleclou
     */
 
     const MetricDataDetails: Array<mt.models.MetricDataDetails> = [{
-        namespace: "mushopnamespace",
-        resourceGroup: "mushop-rg",
+        namespace: "<your_namespace_here>",
+        resourceGroup: "<your_resourcegroup_here>",
         compartmentId: compartmentId,
-        name: "mushop-401-http-error",
+        name: "<your_name_of_the_metric_here>",
         dimensions: {
-            "appName": "Mushop",
-            "podName": "mushop-storefront"
+            "appName": "<your_dimensions>",
+            "podName": "<your_dimensions>"
         },
         metadata: {
             "unit": "count",
-            "displayName": "MuShop Authorization errors"
+            "displayName": "<your_display_name>"
         },
         datapoints: [{
             "timestamp": dateutc,
-            "value": 43,
-            "count": 43
+            "value": "<your_datapoint_value>",
+            "count": "<your_datapoint_count>"
         }
       ]
     }]

--- a/examples/typescript/monitoring-post-metric.ts
+++ b/examples/typescript/monitoring-post-metric.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2020, Oracle and/or its affiliates.  All rights reserved.
+ * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
+ */
+
+ /* @param args Arguments to provide to the example. The following arguments are expected:
+ * <ul>
+ *  <li>The first argument is the OCID of the compartment.</li>
+ * </ul>
+ * Refer https://docs.cloud.oracle.com/en-us/iaas/api/#/en/monitoring/20180401/MetricData/PostMetricData for more details.
+ */
+
+import mt = require("oci-monitoring");
+import common = require("oci-common");
+import { MetricDataDetails } from "oci-monitoring/lib/model";
+
+const configurationFilePath = "~/.oci/config";
+const configProfile = "DEFAULT";
+
+const provider: common.ConfigFileAuthenticationDetailsProvider = new common.ConfigFileAuthenticationDetailsProvider(
+  configurationFilePath,
+  configProfile
+);
+
+const args = process.argv.slice(1);
+console.log(args);
+if (args.length !== 2) {
+  console.error(
+    "Unexpected number of arguments received. Usage : monitoring-alarm.ts <MetricCompartment>"
+  );
+  process.exit(-1);
+}
+
+const compartmentId: string = args[1];
+
+const monitoringClient: mt.MonitoringClient = new mt.MonitoringClient({
+  authenticationDetailsProvider: provider
+});
+monitoringClient.region = common.Region.US_PHOENIX_1;
+monitoringClient.endpoint = "https://telemetry-ingestion.us-phoenix-1.oraclecloud.com";
+
+(async () => {
+  try {
+
+    var datenow = new Date();
+    var dateutc = new Date(datenow.toUTCString());
+    /* The timestamp datapoint format used is defined by RFC3339. 
+    https://docs.cloud.oracle.com/en-us/iaas/api/#/en/monitoring/20180401/datatypes/Datapoint
+    */
+
+    const MetricDataDetails: Array<mt.models.MetricDataDetails> = [{
+        namespace: "mushopnamespace",
+        resourceGroup: "mushop-rg",
+        compartmentId: compartmentId,
+        name: "mushop-401-http-error",
+        dimensions: {
+            "appName": "Mushop",
+            "podName": "mushop-storefront"
+        },
+        metadata: {
+            "unit": "count",
+            "displayName": "MuShop Authorization errors"
+        },
+        datapoints: [{
+            "timestamp": dateutc,
+            "value": 43,
+            "count": 43
+        }
+      ]
+    }]
+
+    const PostMetricDataDetails: mt.models.PostMetricDataDetails = {
+      metricData : MetricDataDetails
+    }
+
+    const PostMetricDataRequest: mt.requests.PostMetricDataRequest = {
+      postMetricDataDetails: PostMetricDataDetails
+    };
+
+    const response =  await monitoringClient.postMetricData(PostMetricDataRequest);
+    //console.log("Retrieved :" + response.postMetricDataResponseDetails.failedMetricsCount);
+
+    console.log("Successfully posted custom metric with name: %s to namespace: %s ",MetricDataDetails[0].name,MetricDataDetails[0].namespace )
+
+  } catch (error) {
+    console.log(" Not able to run post metric monitoring example. Error: " + error);
+  }
+})();


### PR DESCRIPTION
This is an example to Post custom metric to OCI monitoring. 
https://docs.cloud.oracle.com/en-us/iaas/api/#/en/monitoring/20180401/datatypes/MetricDataDetails