### PR TITLE
Upgrade http-signature to 1.3.6 and forcing node-fetch to be on 2.6.7

### DIFF
--- a/lib/common/package.json
+++ b/lib/common/package.json
@@ -24,7 +24,7 @@
     "@types/opossum": "4.1.1",
     "@types/sshpk": "^1.10.3",
     "es6-promise": "4.2.6",
-    "http-signature": "1.3.1",
+    "http-signature": "1.3.6",
     "isomorphic-fetch": "3.0.0",
     "jsonwebtoken": "8.5.1",
     "jssha": "2.4.1",
@@ -44,6 +44,9 @@
     "typescript": "4.1.3",
     "webpack": "4.0.0",
     "webpack-cli": "^3.3.0"
+  },
+  "overrides": {
+    "node-fetch": "2.6.7"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -192,6 +192,9 @@
     "webpack": "4.0.0",
     "webpack-cli": "^3.3.0"
   },
+  "overrides": {
+    "node-fetch": "2.6.7"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged"


### PR DESCRIPTION
Mitigates the below CVEs:

  - CVE-2021-3918 - json-schema is vulnerable to Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
  - CVE-2022-0235 - node-fetch is vulnerable to Exposure of Sensitive Information to an Unauthorized Actor

Signed-off-by: Milan Janecek <milan.janecek@oracle.com>