### PR TITLE
changing default retry configuration to OciSdkDefaultRetryConfiguration on getMessages and putMessages queue methods

### DIFF
--- a/lib/queue/lib/client.ts
+++ b/lib/queue/lib/client.ts
@@ -324,7 +324,7 @@ export class QueueClient {
    * When channelFilter is present, service will return available messages from the channel which ID exactly matched the filter.
    * When filter is not specified, messages will be returned from a random non-empty channel within a queue.
    *
-   * This operation does not retry by default if the user has not defined a retry configuration.
+   * This operation uses {@link common.OciSdkDefaultRetryConfiguration} by default if no retry configuration is defined by the user.
    * @param GetMessagesRequest
    * @return GetMessagesResponse
    * @throws OciError when an error occurs
@@ -352,7 +352,7 @@ export class QueueClient {
       "opc-request-id": getMessagesRequest.opcRequestId
     };
 
-    const specRetryConfiguration = common.NoRetryConfigurationDetails;
+    const specRetryConfiguration = common.OciSdkDefaultRetryConfiguration;
     const retrier = GenericRetrier.createPreferredRetrier(
       this._clientConfiguration ? this._clientConfiguration.retryConfiguration : undefined,
       getMessagesRequest.retryConfiguration,
@@ -560,7 +560,7 @@ export class QueueClient {
    * You must use the [messages endpoint](https://docs.cloud.oracle.com/iaas/Content/queue/messages.htm#messages__messages-endpoint) to produce messages.
    * The messages endpoint may be different for different queues. Use {@link #getQueue(GetQueueRequest) getQueue} to find the queue's `messagesEndpoint`.
    *
-   * This operation does not retry by default if the user has not defined a retry configuration.
+   * This operation uses {@link common.OciSdkDefaultRetryConfiguration} by default if no retry configuration is defined by the user.
    * @param PutMessagesRequest
    * @return PutMessagesResponse
    * @throws OciError when an error occurs
@@ -583,7 +583,7 @@ export class QueueClient {
       "opc-request-id": putMessagesRequest.opcRequestId
     };
 
-    const specRetryConfiguration = common.NoRetryConfigurationDetails;
+    const specRetryConfiguration = common.OciSdkDefaultRetryConfiguration;
     const retrier = GenericRetrier.createPreferredRetrier(
       this._clientConfiguration ? this._clientConfiguration.retryConfiguration : undefined,
       putMessagesRequest.retryConfiguration,
@@ -1813,3 +1813,4 @@ export class QueueAdminClient {
     }
   }
 }
+


### PR DESCRIPTION
For some reason these two methods are not using the default retry configuration `oci.common.OciSdkDefaultRetryConfiguration` as the others methods on this same lib.

It appears to has a problem on the `node-sshpk` library, which is used by `http-signature` which is used by `oci.common.signer.DefaultRequestSigner.signHttpRequest`, that only happens the first time that I try to used it. The message error that I got was this:

```
{
  code: 'ERR_OSSL_DSO_COULD_NOT_LOAD_THE_SHARED_LIBRARY',
  message: 'error:25066067:DSO support routines:dlfcn_load:could not load the shared library',
  requestEndpoint: 'POST https://cell-1.queue.messaging.sa-saopaulo-1.oci.oraclecloud.com/20210201/queues/<queue_id>/messages',
  troubleshootingPage: 'See https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdk_troubleshooting.htm for help troubleshooting this error, or contact support and provide this full error message.'
}
```

Debugging it, this was the line that was throwing the error:
![image](https://github.com/oracle/oci-typescript-sdk/assets/11296869/518aa00b-528c-46ab-9c62-e470a800e40e)


But it was only happening when I used these two methods for first (which drove me crazy for a while).
So I saw that the difference of these methods to the others was the default retry configuration being used. When I changed it to be the same as the others, the problem was gone.