### PR TITLE
calling toLowerCase on a number throws an exception

### DIFF
--- a/lib/common/lib/error.ts
+++ b/lib/common/lib/error.ts
@@ -24,7 +24,7 @@ export class OciError extends Error {
   ) {
     super(message);
 
-    const apiErrorsInfo = `See ${TROUBLESHOOT_LINK}#apierrors_${statusCode}__${statusCode}_${serviceCode.toLowerCase()} for more information about resolving this error`;
+    const apiErrorsInfo = `See ${TROUBLESHOOT_LINK}#apierrors_${statusCode}__${statusCode}_${(serviceCode+'').toLowerCase()} for more information about resolving this error`;
     const contactInfo = `If you are unable to resolve this ${targetService} issue, please contact Oracle support and provide them this full error message.`;
 
     if (apiReferenceLink) {


### PR DESCRIPTION
serviceCode is being parsed as a number and throwing the exception 'toLowerCase is not a function'; this exception hides the original exception being handled.  coercing to a string and calling toLowerCase to handle null, numeric, and blank case