### PR TITLE
fix error logging and custom retry

### DIFF
--- a/lib/common/lib/retrier.ts
+++ b/lib/common/lib/retrier.ts
@@ -243,7 +243,7 @@ export class GenericRetrier {
           requestEndpoint: endpoint,
           troubleshootingPage: `See ${TROUBLESHOOT_URL} for help troubleshooting this error, or contact support and provide this full error message.`
         };
-        shouldBeRetried = true;
+        shouldBeRetried = this.retryConfiguration.retryCondition(errorObject);
       }
       let currentTime = new Date().getTime();
       let timeElapsed = currentTime - timestamp.getTime();
@@ -268,7 +268,7 @@ export class GenericRetrier {
       const delayTime = this.retryConfiguration.delayStrategy.delay(waitContext);
       waitContext.attemptCount++;
       console.warn(
-        `Request failed with Exception : ${lastKnownError}\nRetrying request -> Total Attempts : ${waitContext.attemptCount}, Retrying after ${delayTime} seconds...`
+        `Request failed with Exception : ${lastKnownError}\nRetrying request -> Total Attempts : ${waitContext.attemptCount}, Retrying after ${delayTime} seconds...`,lastKnownError
       );
       await delay(delayTime);
       GenericRetrier.refreshRequest(request);


### PR DESCRIPTION
this fix the logging issue where developer cannot see the real error and see [object object]:
and allow developer to control the retry mechanism.

```
Request failed with Exception : [object Object]
Retrying request -> Total Attempts : 1, Retrying after 1.662 seconds..
```

Signed-off-by: Liron Sher <liron.sher@gmail.com>