### PR TITLE
Try to log the exception message

### DIFF
--- a/lib/common/lib/retrier.ts
+++ b/lib/common/lib/retrier.ts
@@ -269,7 +269,7 @@ export class GenericRetrier {
       const delayTime = this.retryConfiguration.delayStrategy.delay(waitContext);
       waitContext.attemptCount++;
       console.warn(
-        `Request failed with Exception : ${lastKnownError}\nRetrying request -> Total Attempts : ${waitContext.attemptCount}, Retrying after ${delayTime} seconds...`
+        `Request failed with Exception : ${lastKnownError?.message ?? lastKnownError}\nRetrying request -> Total Attempts : ${waitContext.attemptCount}, Retrying after ${delayTime} seconds...`
       );
       await delay(delayTime);
       GenericRetrier.refreshRequest(request);


### PR DESCRIPTION
Since `lastKnownError` is typed as `any` we can't really be sure that `message` is properly set so I kept the fallback of trying to log the object itself.

Fix #293 

I will sign the OCA once I make sure with my employer.