### PR TITLE
fix: waiter circular dependency

### DIFF
--- a/lib/common/lib/waiter.ts
+++ b/lib/common/lib/waiter.ts
@@ -3,7 +3,7 @@
  * This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.
  */
 
-import { OciError } from "..";
+import { OciError } from "./error";
 
 export interface DelayStrategy {
   delay(context: WaitContext): number;


### PR DESCRIPTION
### Circular Dependency in Waiter Module

**Problem:** `lib/common/index.ts` ↔ `lib/common/lib/waiter.ts`

**Solution:** Import `OciError` directly from `./error.ts` in `waiter.ts` instead of from parent index

Reference Issue: https://github.com/oracle/oci-typescript-sdk/issues/391