### PR TITLE
refactor: issue 395 large file removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ lib/**/*.js
 integration-test/*.js
 .vscode
 .DS_Store
+test_file.bin

--- a/lib/common/tests/node-request-generator.spec.ts
+++ b/lib/common/tests/node-request-generator.spec.ts
@@ -33,6 +33,13 @@ describe("Test Request Generator ", () => {
     ? `${clientInfo} (${os.platform}/${os.release}; Node/${process.version}) ${appendUserAgent}`
     : `${clientInfo} (${os.platform}/${os.release}; Node/${process.version})`;
 
+  const testFilePath = __dirname + "/resources/test_file.bin";
+  const largeString = "a".repeat(10485760);
+
+  before(() => {
+    fs.writeFileSync(testFilePath, largeString);
+  });
+
   it("should compose request properly  in Node environment", async function() {
     const sdkRequest = await composeRequest({
       baseEndpoint: "http://test-end-point/20191002",
@@ -61,9 +68,9 @@ describe("Test Request Generator ", () => {
       "Content-Length": undefined,
       "opc-retry-token": undefined
     };
-    const fileLocation = __dirname + "/resources/large_file.bin";
-    const objectData = await fs.createReadStream(fileLocation);
-    const size = fs.statSync(fileLocation).size;
+
+    const objectData = await fs.createReadStream(testFilePath);
+    const size = fs.statSync(testFilePath).size;
     const sdkRequest = await composeRequest({
       baseEndpoint: "http://test-end-point/20191002",
       defaultHeaders: {},
@@ -95,9 +102,9 @@ describe("Test Request Generator ", () => {
       "Content-Length": undefined,
       "opc-retry-token": undefined
     };
-    const fileLocation = __dirname + "/resources/large_file.bin";
-    const size = fs.statSync(fileLocation).size;
-    const objectData = await fs.createReadStream(fileLocation);
+
+    const size = fs.statSync(testFilePath).size;
+    const objectData = await fs.createReadStream(testFilePath);
     objectData.path = ""; // Force the path to be an empty string
     const sdkRequest = await composeRequest({
       baseEndpoint: "http://test-end-point/20191002",
@@ -192,5 +199,11 @@ describe("Test Request Generator ", () => {
     expect(sdkRequest.uri).equals(
       "http://test-end-point/20191002/testUrl/Test-Id/actions?imageId=test&definedTagEquals=namespace1.key.val&definedTagEquals=namespace1.key.val2&definedTagEquals=namespace2.key.val&freeformTagEquals=ff1key.val&freeformTagEquals=ff2key.val"
     );
+  });
+
+  after(() => {
+    // if (fs.existsSync(testFilePath)) {
+    //   fs.rmSync(testFilePath);
+    // }
   });
 });

--- a/lib/common/tests/node-request-generator.spec.ts
+++ b/lib/common/tests/node-request-generator.spec.ts
@@ -202,8 +202,8 @@ describe("Test Request Generator ", () => {
   });
 
   after(() => {
-    // if (fs.existsSync(testFilePath)) {
-    //   fs.rmSync(testFilePath);
-    // }
+    if (fs.existsSync(testFilePath)) {
+      fs.rmSync(testFilePath);
+    }
   });
 });


### PR DESCRIPTION

<img width="442" height="79" alt="image" src="https://github.com/user-attachments/assets/04238124-8a33-4dea-8989-8b913ec3a457" />

There is a 10.5MB file checked into the commit history that is just the letter 'a' 10,485,760 times.

lib/common/tests/resources/large_file.bin

- Removed large_file.bin
- Added just in time large file generation/deletion for reliant unit tests
- Added test_file.bin to .gitignore to avoid mishaps
- added trailing newline to .gitignore

Normally removing a large file that's been checked in wouldn't shrink a git project very much but in this case it does because its easily compressible.

Recommend prior merge of testing harness upgrade: https://github.com/oracle/oci-typescript-sdk/pull/394

Reference issue: https://github.com/oracle/oci-typescript-sdk/issues/395