### PR TITLE
types: use `namespace` instead of deprecated `logger`

### DIFF
--- a/lib/common/lib/log.ts
+++ b/lib/common/lib/log.ts
@@ -16,7 +16,7 @@ export interface Logger {
   trace(message?: any, ...optionalParams: any[]): void;
 }
 
-export module LOG {
+export namespace LOG {
   var _logger: Logger;
 
   export declare var logger: Logger;


### PR DESCRIPTION
Use of the legacy `module` form for declaring a (non-CJS, non-ESM, namespace-style) “module” is a compatibility hazard with TypeScript v6 and v7. See the discussion at [**Announcing TypeScript 6.0 RC: Deprecated: legacy module Syntax for namespaces**][post].

[post]: https://devblogs.microsoft.com/typescript/announcing-typescript-6-0-rc/#deprecated:-legacy-module-syntax-for-namespaces

Fixes #435.