### PR TITLE
Add Macaron GitHub Action Check

### DIFF
--- a/.github/workflows/macaron-check-github-actions.yml
+++ b/.github/workflows/macaron-check-github-actions.yml
@@ -17,8 +17,6 @@ on:
       - ".github/workflows/**"
       - ".github/actions/**"
   workflow_dispatch:
-  schedule:
-    - cron: "0 4 * * 3"
 
 permissions:
   contents: read

--- a/.github/workflows/macaron-check-github-actions.yml
+++ b/.github/workflows/macaron-check-github-actions.yml
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 - 2026, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+# Run Macaron's policies and generate Verification Summary Attestation reports.
+# See https://github.com/oracle/macaron
+
+name: Run Macaron to Check Supply Chain Security Issues
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * 3"
+
+permissions:
+  contents: read
+
+jobs:
+  macaron-check-github-actions:
+    name: Macaron Policy Verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run Macaron Security Analysis Action
+        uses: oracle/macaron@b31acfe389133a5587d9639063ec70cb84e7bc47 # v0.23.0
+        with:
+          repo_path: ./
+          policy_file: check-github-actions
+          policy_purl: pkg:github.com/oracle/oci-typescript-sdk@.*
+          reports_retention_days: 90

--- a/.github/workflows/npmbuildonpullrequest.yml
+++ b/.github/workflows/npmbuildonpullrequest.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/npmbuildonpullrequest.yml
+++ b/.github/workflows/npmbuildonpullrequest.yml
@@ -15,7 +15,7 @@ jobs:
         node-version: [16, 20]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 

--- a/.github/workflows/npmbuildonpullrequest.yml
+++ b/.github/workflows/npmbuildonpullrequest.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize]
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,9 +17,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Log GitHub event
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          echo "PR head ref: ${{ github.event.pull_request.head.ref }}"
-          echo "PR head sha: ${{ github.event.pull_request.head.sha }}"
+          printf 'PR head ref: %s\n' "$PR_HEAD_REF"
+          printf 'PR head sha: %s\n' "$PR_HEAD_SHA"
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/npmbuildonpullrequest.yml
+++ b/.github/workflows/npmbuildonpullrequest.yml
@@ -28,7 +28,7 @@ jobs:
           printf 'PR head sha: %s\n' "$PR_HEAD_SHA"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/releasepublished.yml
+++ b/.github/workflows/releasepublished.yml
@@ -17,6 +17,9 @@ on:
         required: true
         default: latest
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/releasepublished.yml
+++ b/.github/workflows/releasepublished.yml
@@ -124,7 +124,7 @@ jobs:
           cd npm_artifacts
           ls
           cd ..
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: "12.x"
           registry-url: "https://registry.npmjs.org/"


### PR DESCRIPTION
 ## Summary
Add Macaron policy verification for GitHub Actions using the `check-github-actions` policy.

## What this change does
- Adds a dedicated workflow for Macaron verification
- Checks workflow definitions and local composite actions
- Uses pinned actions and disables persisted checkout credentials

## Why this is required
This helps detect unsafe or vulnerable GitHub Actions usage and reduces risk from software supply chain attacks targeting CI/CD pipelines.

## Required follow-up
- [ ] Enable `Macaron policy verification` as a required status check for protected branches
- [x] Resolve any policy findings before merge if applicable