### PR TITLE
Ensure Macaron required check reports on every PR

### DIFF
--- a/.github/workflows/macaron-check-github-actions.yml
+++ b/.github/workflows/macaron-check-github-actions.yml
@@ -7,9 +7,6 @@
 name: Run Macaron to Check Supply Chain Security Issues
 on:
   pull_request:
-    paths:
-      - ".github/workflows/**"
-      - ".github/actions/**"
   push:
     branches:
       - master


### PR DESCRIPTION
- Removed the Pull Request paths from the Macaron workflow so GitHub always creates the required check
- PRs with non-GitHub Actions changes were getting stuck waiting for a skipped required status
