### PR TITLE
Patch Github Action code injection risk

### DIFF
--- a/.github/workflows/npmbuildonpullrequest.yml
+++ b/.github/workflows/npmbuildonpullrequest.yml
@@ -17,14 +17,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Log GitHub event
         env:
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          printf 'PR head ref: %s\n' "$PR_HEAD_REF"
           printf 'PR head sha: %s\n' "$PR_HEAD_SHA"
 
       - name: Setup Node.js


### PR DESCRIPTION
Changed the PR build workflow to use the exact commit SHA instead of the branch name, because the SHA is fixed and trustworthy for that run while the branch name is untrusted and can change.

